### PR TITLE
Test logical sectors in the simulator

### DIFF
--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -45,6 +45,12 @@ jobs:
         - "sig-rsa validate-primary-slot direct-xip multiimage"
         - "sig-ecdsa hw-rollback-protection multiimage"
         - "sig-ed25519 sig-second-key"
+        # Logical sectors: swap bookkeeping in fixed 4K units
+        # independent of the physical page layout. Covers each
+        # upgrade strategy plus a signed variant; exercises the
+        # small-page device (pages smaller than a logical sector)
+        # and the negative tests that reject incompatible layouts.
+        - "logical-sectors-4k,logical-sectors-4k swap-move,logical-sectors-4k swap-offset,logical-sectors-4k overwrite-only,sig-ecdsa logical-sectors-4k"
         - "sig-ecdsa-psa,sig-ecdsa-psa sig-p384,sig-ecdsa-psa swap-move bootstrap max-align-16"
         - "sig-ecdsa-psa enc-ec256 max-align-16, sig-ecdsa-psa enc-ec256 swap-offset validate-primary-slot max-align-16"
         # Same set, routed through Mbed TLS 4.1 via the mbedtls-v4

--- a/.github/workflows/sim.yaml
+++ b/.github/workflows/sim.yaml
@@ -51,6 +51,12 @@ jobs:
         # small-page device (pages smaller than a logical sector)
         # and the negative tests that reject incompatible layouts.
         - "logical-sectors-4k,logical-sectors-4k swap-move,logical-sectors-4k swap-offset,logical-sectors-4k overwrite-only,sig-ecdsa logical-sectors-4k"
+        # 128K logical sectors, where a sector spans several physical
+        # pages of differing sizes. Only the ST devices tile at this
+        # size, and the F769 is the sole device large enough for the
+        # swap algorithms, which its varying page sizes would otherwise
+        # rule out entirely.
+        - "logical-sectors-128k,logical-sectors-128k swap-move,logical-sectors-128k swap-offset,logical-sectors-128k overwrite-only,sig-ecdsa logical-sectors-128k"
         - "sig-ecdsa-psa,sig-ecdsa-psa sig-p384,sig-ecdsa-psa swap-move bootstrap max-align-16"
         - "sig-ecdsa-psa enc-ec256 max-align-16, sig-ecdsa-psa enc-ec256 swap-offset validate-primary-slot max-align-16"
         # Same set, routed through Mbed TLS 4.1 via the mbedtls-v4

--- a/boot/bootutil/src/bootutil_area.c
+++ b/boot/bootutil/src/bootutil_area.c
@@ -118,7 +118,6 @@ boot_header_scramble_off_sz(const struct flash_area *fa, int slot, size_t *off, 
     int ret = 0;
     const size_t write_block = flash_area_align(fa);
     size_t loff = 0;
-    struct flash_sector sector;
 
     BOOT_LOG_DBG("boot_header_scramble_off_sz: slot %d", slot);
 
@@ -128,23 +127,38 @@ boot_header_scramble_off_sz(const struct flash_area *fa, int slot, size_t *off, 
      * in second sector of slot.
      */
     if (slot == BOOT_SLOT_SECONDARY) {
+#if defined(MCUBOOT_LOGICAL_SECTOR_SIZE) && MCUBOOT_LOGICAL_SECTOR_SIZE != 0
+        /* The swap algorithms position slots by logical sectors */
+        loff = MCUBOOT_LOGICAL_SECTOR_SIZE;
+#else
+        struct flash_sector sector;
+
         ret = flash_area_get_sector(fa, 0, &sector);
         if (ret < 0) {
             return ret;
         }
         loff = flash_sector_get_size(&sector);
-        BOOT_LOG_DBG("boot_header_scramble_off_sz: adjusted loff %d", loff);
+#endif
+        BOOT_LOG_DBG("boot_header_scramble_off_sz: adjusted loff %u",
+                     (unsigned int)loff);
     }
 #endif
 
     if (device_requires_erase(fa)) {
+#if defined(MCUBOOT_LOGICAL_SECTOR_SIZE) && MCUBOOT_LOGICAL_SECTOR_SIZE != 0
+        /* The swap algorithms treat logical sectors as erase units */
+        *size = MCUBOOT_LOGICAL_SECTOR_SIZE;
+#else
         /* For device requiring erase align to erase unit */
+        struct flash_sector sector;
+
         ret = flash_area_get_sector(fa, loff, &sector);
         if (ret < 0) {
             return ret;
         }
 
         *size = flash_sector_get_size(&sector);
+#endif
     } else {
         /* For device not requiring erase align to write block */
         *size = ALIGN_UP(sizeof(((struct image_header *)0)->ih_magic), write_block);
@@ -171,6 +185,14 @@ boot_trailer_scramble_offset(const struct flash_area *fa, size_t alignment, size
     }
 
     if (device_requires_erase(fa)) {
+#if defined(MCUBOOT_LOGICAL_SECTOR_SIZE) && MCUBOOT_LOGICAL_SECTOR_SIZE != 0
+        /* The swap algorithms treat the logical sector holding the
+         * trailer as one erase unit, so scramble from its start; the
+         * physical page holding the trailer may be smaller.
+         */
+        *off = ALIGN_DOWN(flash_area_get_size(fa) - boot_trailer_sz(alignment),
+                          MCUBOOT_LOGICAL_SECTOR_SIZE);
+#else
         /* For device requiring erase align to erase unit */
         struct flash_sector sector;
 
@@ -181,6 +203,7 @@ boot_trailer_scramble_offset(const struct flash_area *fa, size_t alignment, size
         }
 
         *off = flash_sector_get_off(&sector);
+#endif
     } else {
         /* For device not requiring erase align to write block */
         *off = flash_area_get_size(fa) - ALIGN_DOWN(boot_trailer_sz(alignment), alignment);

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -53,6 +53,8 @@
 
 BOOT_LOG_MODULE_DECLARE(mcuboot);
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
+
 #if (!defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)) || \
 defined(MCUBOOT_SERIAL_IMG_GRP_SLOT_INFO)
 /* Used for holding static buffers in multiple functions to work around issues
@@ -60,6 +62,7 @@ defined(MCUBOOT_SERIAL_IMG_GRP_SLOT_INFO)
  */
 static struct boot_sector_buffer sector_buffers;
 #endif
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 
 /**
  * @brief Determine if the data at two memory addresses is equal
@@ -432,6 +435,7 @@ done:
 
 #if (!defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)) || \
 defined(MCUBOOT_SERIAL_IMG_GRP_SLOT_INFO)
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 int
 boot_initialize_area(struct boot_loader_state *state, int flash_area)
 {
@@ -472,6 +476,139 @@ boot_initialize_area(struct boot_loader_state *state, int flash_area)
     return 0;
 }
 
+#else /* defined(MCUBOOT_LOGICAL_SECTOR_SIZE) && MCUBOOT_LOGICAL_SECTOR_SIZE != 0 */
+#if defined(MCUBOOT_VERIFY_LOGICAL_SECTORS)
+/* Validation can only run once all flash areas are open and pointers to
+ * flash area objects are stored in state.
+ */
+static int
+boot_verify_logical_sectors(int faid, const struct flash_area *fa)
+{
+    uint32_t slot_size;
+    uint32_t slot_off;
+    uint32_t sect_off = 0;
+    int rc;
+    int final_rc = 0;
+    bool device_with_erase;
+    uint32_t wbs;
+
+    assert(fa != NULL);
+    assert(faid != 0);
+
+    slot_off = (uint32_t)flash_area_get_off(fa);
+    slot_size = (uint32_t)flash_area_get_size(fa);
+
+    wbs = flash_area_align(fa);
+
+    device_with_erase = device_requires_erase(fa);
+    /* Go till all verifications are complete or we face issue that does not allow
+     * to precede with further tests.
+     */
+    BOOT_LOG_INF("boot_verify_logical_sectors: verify flash area %p", fa);
+    BOOT_LOG_INF("boot_verify_logical_sectors: MCUBOOT_LOGICAL_SECTOR_SIZE == 0x%x",
+                 MCUBOOT_LOGICAL_SECTOR_SIZE);
+    BOOT_LOG_INF("boot_verify_logical_sectors: slot offset == 0x%x", slot_off);
+    if (slot_size != 0) {
+        BOOT_LOG_INF("boot_verify_logical_sectors: slot size == 0x%x", slot_size);
+    } else {
+        BOOT_LOG_ERR("boot_verify_logical_sectors: 0 size slot");
+        return BOOT_EFLASH;
+    }
+    BOOT_LOG_INF("boot_verify_logical_sectors: write block size %u", wbs);
+    BOOT_LOG_INF("boot_verify_logical_sectors: device with%s erase",
+                 device_with_erase ? "" : "out");
+
+    /* We are expecting slot size to be multiple of logical sector size.
+     * Note though that we do not check alignment of the slot to logical sector.
+     * as it does not matter, only alignment of slot to a real erase page
+     * matters.
+     */
+    if (slot_size % MCUBOOT_LOGICAL_SECTOR_SIZE) {
+        BOOT_LOG_ERR("boot_verify_logical_sectors: area size not aligned");
+        final_rc = BOOT_EFLASH;
+    }
+
+    BOOT_LOG_INF("boot_verify_logical_sectors: max %d logical sectors",
+                 slot_size / MCUBOOT_LOGICAL_SECTOR_SIZE);
+
+    if (device_with_erase) {
+        size_t total_scanned = 0;
+
+        /* Check all logical sectors pages against erase pages of a device */
+        while (total_scanned < slot_size) {
+            struct flash_sector fas;
+
+            MCUBOOT_WATCHDOG_FEED();
+
+            BOOT_LOG_INF("boot_verify_logical_sectors: page 0x%x:0x%x ", slot_off, sect_off);
+            rc = flash_area_get_sector(fa, sect_off, &fas);
+            if (rc < 0) {
+                BOOT_LOG_ERR("boot_verify_logical_sectors: query err %d", rc);
+                final_rc = BOOT_EFLASH;
+                continue;
+            }
+
+            /* Jumping by logical sector size should align us with real erase page
+             * each time.
+             */
+            if (sect_off != flash_sector_get_off(&fas)) {
+                BOOT_LOG_ERR("boot_verify_logical_sectors: misaligned offset (0x%x)",
+                             (uint32_t)flash_sector_get_off(&fas));
+                final_rc = BOOT_EFLASH;
+            }
+
+            /* Jumping by logical sector size */
+            sect_off += MCUBOOT_LOGICAL_SECTOR_SIZE;
+            total_scanned += MCUBOOT_LOGICAL_SECTOR_SIZE;
+        }
+    } else {
+        /* Devices with no-explicit erase require alignment to write block size */
+
+        if (MCUBOOT_LOGICAL_SECTOR_SIZE % wbs) {
+            BOOT_LOG_ERR("boot_verify_logical_sectors: sector size not aligned to write block");
+            final_rc = BOOT_EFLASH;
+        }
+
+        if (slot_off % wbs) {
+            BOOT_LOG_ERR("boot_verify_logical_sectors: slot not aligned to write block");
+            final_rc = BOOT_EFLASH;
+        }
+    }
+
+    BOOT_LOG_INF("boot_verify_logical_sectors: completed (%d)", final_rc);
+
+    return final_rc;
+}
+#endif /* MCUBOOT_LOGICAL_SECTOR_VALIDATION */
+
+static int
+boot_initialize_area(struct boot_loader_state *state, int flash_area)
+{
+    size_t area_size;
+    uint32_t *out_num_sectors;
+
+    if (flash_area == FLASH_AREA_IMAGE_PRIMARY(BOOT_CURR_IMG(state))) {
+        area_size = flash_area_get_size(BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY));
+        out_num_sectors = &BOOT_IMG(state, BOOT_SLOT_PRIMARY).num_sectors;
+    } else if (flash_area == FLASH_AREA_IMAGE_SECONDARY(BOOT_CURR_IMG(state))) {
+        area_size = flash_area_get_size(BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY));
+        out_num_sectors = &BOOT_IMG(state, BOOT_SLOT_SECONDARY).num_sectors;
+#if MCUBOOT_SWAP_USING_SCRATCH
+    } else if (flash_area == FLASH_AREA_IMAGE_SCRATCH) {
+        area_size = flash_area_get_size(state->scratch.area);
+        out_num_sectors = &state->scratch.num_sectors;
+#endif
+    } else {
+        return BOOT_EFLASH;
+    }
+
+    *out_num_sectors = area_size / MCUBOOT_LOGICAL_SECTOR_SIZE;
+
+    return 0;
+}
+
+#endif /* defined(MCUBOOT_LOGICAL_SECTOR_SIZE) && MCUBOOT_LOGICAL_SECTOR_SIZE != 0 */
+
 static uint32_t
 boot_write_sz(struct boot_loader_state *state)
 {
@@ -501,11 +638,12 @@ boot_read_sectors(struct boot_loader_state *state, struct boot_sector_buffer *se
     uint8_t image_index;
     int rc;
 
+    image_index = BOOT_CURR_IMG(state);
+
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
     if (sectors == NULL) {
         sectors = &sector_buffers;
     }
-
-    image_index = BOOT_CURR_IMG(state);
 
     BOOT_IMG(state, BOOT_SLOT_PRIMARY).sectors =
         sectors->primary[image_index];
@@ -516,6 +654,9 @@ boot_read_sectors(struct boot_loader_state *state, struct boot_sector_buffer *se
     state->scratch.sectors = sectors->scratch;
 #endif
 #endif
+#else
+    (void)sectors;
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 
     rc = boot_initialize_area(state, FLASH_AREA_IMAGE_PRIMARY(image_index));
     if (rc != 0) {
@@ -538,6 +679,28 @@ boot_read_sectors(struct boot_loader_state *state, struct boot_sector_buffer *se
 #endif
 
     BOOT_WRITE_SZ(state) = boot_write_sz(state);
+
+#if defined(MCUBOOT_VERIFY_LOGICAL_SECTORS)
+    BOOT_LOG_INF("boot_read_sectors: verify image %d slots", image_index);
+    BOOT_LOG_INF("boot_read_sectors: BOOT_SLOT_PRIMARY");
+    if (boot_verify_logical_sectors(FLASH_AREA_IMAGE_PRIMARY(image_index),
+        BOOT_IMG_AREA(state, BOOT_SLOT_PRIMARY)) != 0) {
+        rc = BOOT_EFLASH;
+    }
+
+    BOOT_LOG_INF("boot_read_sectors: BOOT_SLOT_SECONDARY");
+    if (boot_verify_logical_sectors(FLASH_AREA_IMAGE_SECONDARY(image_index),
+        BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) != 0) {
+        rc = BOOT_EFLASH_SEC;
+    }
+
+#if MCUBOOT_SWAP_USING_SCRATCH
+    BOOT_LOG_INF("boot_read_sectors: SCRATCH");
+    if (boot_verify_logical_sectors(FLASH_AREA_IMAGE_SCRATCH, state->scratch.area) != 0) {
+        rc = BOOT_EFLASH;
+    }
+#endif /* MCUBOOT_SWAP_USING_SCRATCH */
+#endif /* defined(MCUBOOT_LOGICAL_SECTOR_VALIDATION) */
 
     return 0;
 }

--- a/boot/bootutil/src/bootutil_misc.c
+++ b/boot/bootutil/src/bootutil_misc.c
@@ -689,9 +689,14 @@ boot_read_sectors(struct boot_loader_state *state, struct boot_sector_buffer *se
     }
 
     BOOT_LOG_INF("boot_read_sectors: BOOT_SLOT_SECONDARY");
+    /* A verification failure means the configured logical sector size
+     * does not match the device, so no slot may be modified; report
+     * BOOT_EFLASH rather than BOOT_EFLASH_SEC so the caller does not
+     * attempt an upgrade based on the mismatched layout.
+     */
     if (boot_verify_logical_sectors(FLASH_AREA_IMAGE_SECONDARY(image_index),
         BOOT_IMG_AREA(state, BOOT_SLOT_SECONDARY)) != 0) {
-        rc = BOOT_EFLASH_SEC;
+        rc = BOOT_EFLASH;
     }
 
 #if MCUBOOT_SWAP_USING_SCRATCH
@@ -700,9 +705,9 @@ boot_read_sectors(struct boot_loader_state *state, struct boot_sector_buffer *se
         rc = BOOT_EFLASH;
     }
 #endif /* MCUBOOT_SWAP_USING_SCRATCH */
-#endif /* defined(MCUBOOT_LOGICAL_SECTOR_VALIDATION) */
+#endif /* defined(MCUBOOT_VERIFY_LOGICAL_SECTORS) */
 
-    return 0;
+    return rc;
 }
 #endif
 

--- a/boot/bootutil/src/bootutil_priv.h
+++ b/boot/bootutil/src/bootutil_priv.h
@@ -221,7 +221,9 @@ struct boot_loader_state {
     struct {
         struct image_header hdr;
         const struct flash_area *area;
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
         boot_sector_t *sectors;
+#endif
         uint32_t num_sectors;
 #if defined(MCUBOOT_SWAP_USING_OFFSET)
         uint16_t unprotected_tlv_size;
@@ -231,7 +233,9 @@ struct boot_loader_state {
 #if MCUBOOT_SWAP_USING_SCRATCH
     struct {
         const struct flash_area *area;
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
         boot_sector_t *sectors;
+#endif
         uint32_t num_sectors;
     } scratch;
 #endif
@@ -466,6 +470,7 @@ boot_img_slot_off(struct boot_loader_state *state, size_t slot)
     return flash_area_get_off(BOOT_IMG_AREA(state, slot));
 }
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 #ifndef MCUBOOT_USE_FLASH_AREA_GET_SECTORS
 
 static inline size_t
@@ -505,6 +510,32 @@ boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
 }
 
 #endif  /* !defined(MCUBOOT_USE_FLASH_AREA_GET_SECTORS) */
+#else
+static inline size_t
+boot_img_sector_size(const struct boot_loader_state *state,
+                     size_t slot, size_t sector)
+{
+    (void)state;
+    (void)slot;
+    (void)sector;
+
+    return MCUBOOT_LOGICAL_SECTOR_SIZE;
+}
+
+/*
+ * Offset of the sector from the beginning of the image, NOT the flash
+ * device.
+ */
+static inline uint32_t
+boot_img_sector_off(const struct boot_loader_state *state, size_t slot,
+                    size_t sector)
+{
+    (void)state;
+    (void)slot;
+
+    return MCUBOOT_LOGICAL_SECTOR_SIZE * sector;
+}
+#endif
 
 #ifdef MCUBOOT_RAM_LOAD
 #   ifdef __BOOTSIM__

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -460,6 +460,7 @@ boot_write_status(const struct boot_loader_state *state, struct boot_status *bs)
 #endif /* !MCUBOOT_DIRECT_XIP */
 
 #if !defined(MCUBOOT_DIRECT_XIP) && !defined(MCUBOOT_RAM_LOAD)
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 static fih_ret
 split_image_check(struct image_header *app_hdr,
                   const struct flash_area *app_fap,
@@ -490,6 +491,7 @@ split_image_check(struct image_header *app_hdr,
 out:
     FIH_RET(fih_rc);
 }
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 #endif /* !MCUBOOT_DIRECT_XIP && !MCUBOOT_RAM_LOAD */
 
 #if defined(MCUBOOT_DIRECT_XIP)
@@ -1710,10 +1712,12 @@ context_boot_go(struct boot_loader_state *state, struct boot_rsp *rsp)
 
     BOOT_LOG_DBG("context_boot_go");
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 #if defined(__BOOTSIM__)
     struct boot_sector_buffer sector_buf;
     sectors = &sector_buf;
 #endif
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 
     has_upgrade = false;
 
@@ -1973,6 +1977,7 @@ out:
     FIH_RET(fih_rc);
 }
 
+#if !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0
 fih_ret
 split_go(int loader_slot, int split_slot, void **entry)
 {
@@ -2038,6 +2043,7 @@ done:
 
     FIH_RET(fih_rc);
 }
+#endif /* !defined(MCUBOOT_LOGICAL_SECTOR_SIZE) || MCUBOOT_LOGICAL_SECTOR_SIZE == 0 */
 
 #else /* MCUBOOT_DIRECT_XIP || MCUBOOT_RAM_LOAD */
 

--- a/boot/zephyr/Kconfig
+++ b/boot/zephyr/Kconfig
@@ -1460,6 +1460,27 @@ config MCUBOOT_VERIFY_IMG_ADDRESS
 	  also be useful when BOOT_DIRECT_XIP is enabled, to ensure that the image
 	  linked at the correct address is loaded.
 
+config MCUBOOT_LOGICAL_SECTOR_SIZE
+	int "Size of a logical sector"
+	default 0
+	help
+	  Set to 0 to use hardware sectors. Any other value here should be
+	  aligned to hardware sectors in size and alignment.
+
+config MCUBOOT_LOGICAL_SECTOR_SIZE_SET
+	bool
+	default y
+	depends on MCUBOOT_LOGICAL_SECTOR_SIZE != 0
+
+config MCUBOOT_VERIFY_LOGICAL_SECTORS
+	bool "Validate logical sector layout"
+	default y
+	depends on MCUBOOT_LOGICAL_SECTOR_SIZE_SET
+	help
+	  Validation of logical sector size against hardware constrains.
+	  Should be used to validate compile-time configuration against run-time
+	  system.
+
 config MCUBOOT_DEVICE_SETTINGS
 	# Hidden selector for device-specific settings
 	bool
@@ -1468,6 +1489,9 @@ config MCUBOOT_DEVICE_SETTINGS
 	select MCUBOOT_DEVICE_CPU_CORTEX_M0 if CPU_CORTEX_M0
 	# Enable flash page layout if available
 	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT
+    # Enable flash page layout if available
+	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT && !MCUBOOT_LOGICAL_SECTOR_SIZE_SET
+	select FLASH_PAGE_LAYOUT if FLASH_HAS_PAGE_LAYOUT && MCUBOOT_VERIFY_LOGICAL_SECTORS
 	# Enable flash_map module as flash I/O back-end
 	select FLASH_MAP
 

--- a/boot/zephyr/flash_map_extended.c
+++ b/boot/zephyr/flash_map_extended.c
@@ -294,7 +294,7 @@ int flash_area_get_sector(const struct flash_area *fap, off_t off,
     struct flash_pages_info fpi;
     int rc;
 
-    if (off < 0 || (size_t) off >= fap->fa_size) {
+    if (off < 0 || (size_t)off >= fap->fa_size) {
         return -ERANGE;
     }
 
@@ -308,3 +308,27 @@ int flash_area_get_sector(const struct flash_area *fap, off_t off,
 
     return rc;
 }
+#else
+int flash_area_sector_from_off(off_t off, struct flash_sector *sector)
+{
+    sector->fs_off = off & ~(CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE - 1);
+    sector->fs_size = CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE;
+
+    return 0;
+}
+
+int flash_area_get_sector(const struct flash_area *fap, off_t off,
+                          struct flash_sector *fsp)
+{
+    if (off < 0 || (size_t)off >= flash_area_get_size(fap)) {
+	BOOT_LOG_ERR("flash_area_get_sector: off %ld out of area %p",
+                     (long)off, fap);
+        return -ERANGE;
+    }
+
+    fsp->fs_off = off & ~(CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE - 1);
+    fsp->fs_size = CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE;
+
+    return 0;
+}
+#endif

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -422,6 +422,27 @@
 #  endif
 #endif
 
+/* If set to non-0 it will use logical sectors rather than querying
+ * device for sector sizes. This slightly reduces code and RAM usage.
+ * Note that the logical sector size has to be multiple of erase
+ * sector size that is biggest for of all devices in the system.
+ */
+#if defined(CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE)
+#define MCUBOOT_LOGICAL_SECTOR_SIZE		CONFIG_MCUBOOT_LOGICAL_SECTOR_SIZE
+#endif
+
+/* Enable to validate compile time logical sector setup vs the real device layout.
+ * This increases the size of bootloader, but is useful to check whether
+ * selected logical sector size can be used with provided partitions
+ * and devices they are placed on.
+ * Once layout is tested, this option should be disabled for production
+ * devices, as it is pointless to re-validate non-changing setup on
+ * every MCUboot run.
+ */
+#if defined(CONFIG_MCUBOOT_VERIFY_LOGICAL_SECTORS)
+#define MCUBOOT_VERIFY_LOGICAL_SECTORS	1
+#endif
+
 #if defined(CONFIG_BOOT_MAX_IMG_SECTORS_AUTO) && defined(MIN_SECTOR_COUNT)
 
 #define MCUBOOT_MAX_IMG_SECTORS       MIN_SECTOR_COUNT

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -40,6 +40,7 @@ hw-rollback-protection = ["mcuboot-sys/hw-rollback-protection"]
 check-load-addr = ["mcuboot-sys/check-load-addr"]
 custom-crypto = ["mcuboot-sys/custom-crypto"]
 custom-enc-crypto = ["mcuboot-sys/custom-enc-crypto"]
+logical-sectors-4k= ["mcuboot-sys/logical-sectors-4k"]
 
 [dependencies]
 byteorder = "1.4"

--- a/sim/Cargo.toml
+++ b/sim/Cargo.toml
@@ -40,7 +40,9 @@ hw-rollback-protection = ["mcuboot-sys/hw-rollback-protection"]
 check-load-addr = ["mcuboot-sys/check-load-addr"]
 custom-crypto = ["mcuboot-sys/custom-crypto"]
 custom-enc-crypto = ["mcuboot-sys/custom-enc-crypto"]
-logical-sectors-4k= ["mcuboot-sys/logical-sectors-4k"]
+logical-sectors = ["mcuboot-sys/logical-sectors"]
+logical-sectors-4k = ["logical-sectors", "mcuboot-sys/logical-sectors-4k"]
+logical-sectors-128k = ["logical-sectors", "mcuboot-sys/logical-sectors-128k"]
 
 [dependencies]
 byteorder = "1.4"

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -102,6 +102,9 @@ max-align-16 = []
 # Support images with 32-byte maximum write alignment value.
 max-align-32 = []
 
+# Use logical sectors
+logical-sectors-4k = []
+
 # Enable hardware rollback protection
 hw-rollback-protection = []
 

--- a/sim/mcuboot-sys/Cargo.toml
+++ b/sim/mcuboot-sys/Cargo.toml
@@ -102,8 +102,12 @@ max-align-16 = []
 # Support images with 32-byte maximum write alignment value.
 max-align-32 = []
 
-# Use logical sectors
-logical-sectors-4k = []
+# Use logical sectors.  Enable exactly one of the sized features; each
+# implies the `logical-sectors` umbrella that code can test against
+# without caring about the size.
+logical-sectors = []
+logical-sectors-4k = ["logical-sectors"]
+logical-sectors-128k = ["logical-sectors"]
 
 # Enable hardware rollback protection
 hw-rollback-protection = []

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -47,6 +47,7 @@ fn main() {
     let custom_enc_crypto = env::var("CARGO_FEATURE_CUSTOM_ENC_CRYPTO").is_ok();
     let mbedtls_v4 = env::var("CARGO_FEATURE_MBEDTLS_V4").is_ok();
     let logical_sectors_4k = env::var("CARGO_FEATURE_LOGICAL_SECTORS_4K").is_ok();
+    let logical_sectors_128k = env::var("CARGO_FEATURE_LOGICAL_SECTORS_128K").is_ok();
 
     let mut conf = CachedBuild::new();
     conf.conf.define("__BOOTSIM__", None);
@@ -63,8 +64,14 @@ fn main() {
         conf.conf.define("MCUBOOT_BOOT_MAX_ALIGN", Some("8"));
     }
 
-    if logical_sectors_4k {
-        conf.conf.define("MCUBOOT_LOGICAL_SECTOR_SIZE", Some("4096"));
+    let logical_sector_size = match (logical_sectors_4k, logical_sectors_128k) {
+        (true, true) => panic!("only one logical-sectors-* feature may be enabled"),
+        (true, false) => Some("4096"),
+        (false, true) => Some("131072"),
+        (false, false) => None,
+    };
+    if let Some(size) = logical_sector_size {
+        conf.conf.define("MCUBOOT_LOGICAL_SECTOR_SIZE", Some(size));
         conf.conf.define("MCUBOOT_VERIFY_LOGICAL_SECTORS", None);
     }
 

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -46,6 +46,7 @@ fn main() {
     let custom_crypto = env::var("CARGO_FEATURE_CUSTOM_CRYPTO").is_ok();
     let custom_enc_crypto = env::var("CARGO_FEATURE_CUSTOM_ENC_CRYPTO").is_ok();
     let mbedtls_v4 = env::var("CARGO_FEATURE_MBEDTLS_V4").is_ok();
+    let logical_sectors_4k = env::var("CARGO_FEATURE_LOGICAL_SECTORS_4K").is_ok();
 
     let mut conf = CachedBuild::new();
     conf.conf.define("__BOOTSIM__", None);
@@ -60,6 +61,10 @@ fn main() {
         conf.conf.define("MCUBOOT_BOOT_MAX_ALIGN", Some("16"));
     } else {
         conf.conf.define("MCUBOOT_BOOT_MAX_ALIGN", Some("8"));
+    }
+
+    if logical_sectors_4k {
+        conf.conf.define("MCUBOOT_LOGICAL_SECTOR_SIZE", Some("4096"));
     }
 
     conf.conf.define("MCUBOOT_IMAGE_NUMBER", Some(if multiimage { "2" } else { "1" }));

--- a/sim/mcuboot-sys/build.rs
+++ b/sim/mcuboot-sys/build.rs
@@ -65,6 +65,7 @@ fn main() {
 
     if logical_sectors_4k {
         conf.conf.define("MCUBOOT_LOGICAL_SECTOR_SIZE", Some("4096"));
+        conf.conf.define("MCUBOOT_VERIFY_LOGICAL_SECTORS", None);
     }
 
     conf.conf.define("MCUBOOT_IMAGE_NUMBER", Some(if multiimage { "2" } else { "1" }));

--- a/sim/mcuboot-sys/src/area.rs
+++ b/sim/mcuboot-sys/src/area.rs
@@ -157,12 +157,24 @@ impl AreaDesc {
             .find(|area| area[0].flash_id == flash_id)
     }
 
-    /// Whether every area can be represented by logical sectors of `size`.
-    /// Each logical boundary must coincide with a hardware erase boundary.
-    /// This mirrors the check `boot_verify_logical_sectors()` performs, so a
-    /// device this rejects is one the bootloader will refuse to touch.
-    pub fn supports_logical_sector_size(&self, size: usize) -> bool {
-        size != 0 && self.areas.iter().filter(|area| !area.is_empty()).all(|area| {
+    /// The areas the bootloader checks against the logical sector size.
+    /// `boot_read_sectors()` verifies the scratch area only when
+    /// MCUBOOT_SWAP_USING_SCRATCH is set, so a scratch area that does not
+    /// tile is irrelevant to the algorithms that never erase it.
+    fn logical_sector_areas(&self, with_scratch: bool)
+                            -> impl Iterator<Item = &Vec<FlashArea>> {
+        self.areas.iter()
+            .filter(|area| !area.is_empty())
+            .filter(move |area| with_scratch || area[0].flash_id != FlashId::ImageScratch)
+    }
+
+    /// Whether every checked area can be represented by logical sectors of
+    /// `size`.  Each logical boundary must coincide with a hardware erase
+    /// boundary.  This mirrors the check `boot_verify_logical_sectors()`
+    /// performs, so a device this rejects is one the bootloader will refuse
+    /// to touch.
+    pub fn supports_logical_sector_size(&self, size: usize, with_scratch: bool) -> bool {
+        size != 0 && self.logical_sector_areas(with_scratch).all(|area| {
             let mut logical_offset = 0usize;
             area.iter().all(|sector| {
                 let sector_size = sector.size as usize;
@@ -176,6 +188,14 @@ impl AreaDesc {
                 true
             }) && logical_offset == 0
         })
+    }
+
+    /// Whether every checked area is already built from erase pages of
+    /// exactly `size`, so logical sectors of that size change nothing about
+    /// the erase units the bootloader sees.
+    pub fn uses_native_sector_size(&self, size: usize, with_scratch: bool) -> bool {
+        self.logical_sector_areas(with_scratch)
+            .all(|area| area.iter().all(|sector| sector.size as usize == size))
     }
 }
 

--- a/sim/mcuboot-sys/src/area.rs
+++ b/sim/mcuboot-sys/src/area.rs
@@ -156,6 +156,27 @@ impl AreaDesc {
             .filter(|area| !area.is_empty())
             .find(|area| area[0].flash_id == flash_id)
     }
+
+    /// Whether every area can be represented by logical sectors of `size`.
+    /// Each logical boundary must coincide with a hardware erase boundary.
+    /// This mirrors the check `boot_verify_logical_sectors()` performs, so a
+    /// device this rejects is one the bootloader will refuse to touch.
+    pub fn supports_logical_sector_size(&self, size: usize) -> bool {
+        size != 0 && self.areas.iter().filter(|area| !area.is_empty()).all(|area| {
+            let mut logical_offset = 0usize;
+            area.iter().all(|sector| {
+                let sector_size = sector.size as usize;
+                if sector_size > size || logical_offset + sector_size > size {
+                    return false;
+                }
+                logical_offset += sector_size;
+                if logical_offset == size {
+                    logical_offset = 0;
+                }
+                true
+            }) && logical_offset == 0
+        })
+    }
 }
 
 /// The area descriptor, C format.

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -67,6 +67,16 @@ impl BootGoResult {
     }
 }
 
+/// The logical sector size compiled into MCUboot, or zero when the feature is
+/// disabled.  Must agree with the MCUBOOT_LOGICAL_SECTOR_SIZE that build.rs
+/// defines for the same features.
+pub const fn logical_sector_size() -> usize {
+    #[cfg(feature = "logical-sectors-4k")]
+    { return 4 * 1024; }
+    #[allow(unreachable_code)]
+    0
+}
+
 /// Invoke the bootloader on this flash device.
 pub fn boot_go(multiflash: &mut SimMultiFlash, areadesc: &AreaDesc,
                counter: Option<&mut i32>, image_index: Option<i32>,

--- a/sim/mcuboot-sys/src/c.rs
+++ b/sim/mcuboot-sys/src/c.rs
@@ -73,6 +73,8 @@ impl BootGoResult {
 pub const fn logical_sector_size() -> usize {
     #[cfg(feature = "logical-sectors-4k")]
     { return 4 * 1024; }
+    #[cfg(feature = "logical-sectors-128k")]
+    { return 128 * 1024; }
     #[allow(unreachable_code)]
     0
 }

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -218,8 +218,13 @@ impl ImagesBuilder {
     }
 
     fn device_usable(dev: DeviceName) -> Result<(), String> {
-        if cfg!(feature = "logical-sectors-4k") && !Self::device_supports_logical_sectors(dev) {
-            return Err("sector layout incompatible with logical sectors".to_string());
+        if cfg!(feature = "logical-sectors-4k") {
+            if !Self::device_supports_logical_sectors(dev) {
+                return Err("sector layout incompatible with logical sectors".to_string());
+            }
+        } else if matches!(dev, DeviceName::SmallPages) {
+            return Err("slots have more pages than BOOT_MAX_IMG_SECTORS; \
+                        requires logical sectors".to_string());
         }
         Ok(())
     }
@@ -685,6 +690,26 @@ impl ImagesBuilder {
                 areadesc.add_image(0x060000, 0x001000, FlashId::ImageScratch, dev_id);
                 areadesc.add_image(0x080000, 0x020000, FlashId::Image2, dev_id);
                 areadesc.add_image(0x0a0000, 0x020000, FlashId::Image3, dev_id);
+
+                let mut flash = SimMultiFlash::new();
+                flash.insert(dev_id, dev);
+                (flash, Rc::new(areadesc), &[])
+            }
+            DeviceName::SmallPages => {
+                // A device with erase pages much smaller than the logical
+                // sector size.  Each 128K slot spans 256 physical pages,
+                // which exceeds BOOT_MAX_IMG_SECTORS (128), so this device
+                // is only bootable when logical sectors group the pages
+                // into fewer, larger units.  This is the configuration the
+                // logical sector support exists for.
+                let dev = SimFlash::new(vec![512; 1024], align as usize, erased_val);
+
+                let dev_id = 0;
+                let mut areadesc = AreaDesc::new();
+                areadesc.add_flash_sectors(dev_id, &dev);
+                areadesc.add_image(0x020000, 0x020000, FlashId::Image0, dev_id);
+                areadesc.add_image(0x040000, 0x020000, FlashId::Image1, dev_id);
+                areadesc.add_image(0x060000, 0x004000, FlashId::ImageScratch, dev_id);
 
                 let mut flash = SimMultiFlash::new();
                 flash.insert(dev_id, dev);
@@ -1957,6 +1982,19 @@ enum ImageSize {
     Oversized,
 }
 
+/// The sector size the bootloader operates on for `dev`: the logical
+/// sector size when the simulator is built with logical sectors, the
+/// device's physical sector size otherwise.  The size here must match
+/// the MCUBOOT_LOGICAL_SECTOR_SIZE value set by mcuboot-sys/build.rs.
+/// The physical case assumes uniform sectors, as does every caller.
+fn boot_sector_size(dev: &dyn Flash) -> usize {
+    if cfg!(feature = "logical-sectors-4k") {
+        4096
+    } else {
+        dev.sector_iter().next().unwrap().size
+    }
+}
+
 /// Estimate the number of bytes in each slot that must be reserved for the trailer when
 /// swap-scratch is used.
 fn estimate_swap_scratch_trailer_size(dev: &dyn Flash, areadesc: &AreaDesc, slot: &SlotInfo) -> usize {
@@ -1975,11 +2013,17 @@ fn estimate_swap_scratch_trailer_size(dev: &dyn Flash, areadesc: &AreaDesc, slot
         _ => panic!("Invalid slot index"),
     };
 
-    let slot_sectors = areadesc.get_area_sectors(flash_id).unwrap();
+    // Sector sizes as seen by the bootloader: uniform logical sectors
+    // when they are enabled, the physical layout otherwise.
+    let slot_sectors: Vec<usize> = if cfg!(feature = "logical-sectors-4k") {
+        let sector_sz = boot_sector_size(dev);
+        vec![sector_sz; slot.len / sector_sz]
+    } else {
+        areadesc.get_area_sectors(flash_id).unwrap()
+            .iter().map(|sector| sector.size as usize).collect()
+    };
 
-    for sector in slot_sectors.iter().rev() {
-        let sector_sz = sector.size as usize;
-
+    for &sector_sz in slot_sectors.iter().rev() {
         if sector_sz > trailer_sz_in_fw_sector {
             break;
         }
@@ -2011,7 +2055,7 @@ fn image_largest_trailer(dev: &dyn Flash, areadesc: &AreaDesc, slot: &SlotInfo) 
                 // magic + image-ok + copy-done + swap-info
                 c::boot_magic_sz() + 3 * c::boot_max_align()
             } else if Caps::SwapUsingOffset.present() || Caps::SwapUsingMove.present() {
-                let sector_size = dev.sector_iter().next().unwrap().size as u32;
+                let sector_size = boot_sector_size(dev) as u32;
                 align_up(c::boot_trailer_sz(dev.align() as u32), sector_size) as usize
             } else if Caps::SwapUsingScratch.present() {
                 estimate_swap_scratch_trailer_size(dev, areadesc, slot)
@@ -2029,9 +2073,7 @@ fn required_slot_padding(dev: &dyn Flash) -> usize {
 
     if Caps::SwapUsingMove.present() || Caps::SwapUsingOffset.present() {
         // Assumes equally-sized sectors
-        let sector_size = dev.sector_iter().next().unwrap().size;
-
-        required_padding = sector_size;
+        required_padding = boot_sector_size(dev);
     };
 
     required_padding
@@ -2094,8 +2136,7 @@ fn install_image_with_key(
     let mut tlv: Box<dyn ManifestGen> = Box::new(make_tlv(signing_key));
 
     if Caps::SwapUsingOffset.present() && slot_ind == 1 {
-        let sector_size = dev.sector_iter().next().unwrap().size as usize;
-        offset += sector_size;
+        offset += boot_sector_size(dev);
     }
 
     if img_manipulation == ImageManipulation::IgnoreRamLoadFlag {
@@ -2390,7 +2431,7 @@ fn verify_image(flash: &SimMultiFlash, slot: &SlotInfo, images: &ImageData) -> b
     dev.read(offset, &mut copy).unwrap();
 
     if Caps::SwapUsingOffset.present() && (slot.index % 2) == 1 {
-        let sector_size = dev.sector_iter().next().unwrap().size as usize;
+        let sector_size = boot_sector_size(dev);
         let mut copy_offset = vec![0u8; buf.len()];
         let offset_offset = slot.base_off + sector_size;
         dev.read(offset_offset, &mut copy_offset).unwrap();

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -140,9 +140,42 @@ impl ImagesBuilder {
     pub fn new(device: DeviceName, align: usize, erased_val: u8) -> Result<Self, String> {
         let (flash, areadesc, unsupported_caps) = Self::make_device(device, align, erased_val);
 
+        // Swap-move and swap-offset require uniformly sized erase units, which
+        // is why devices with varying page sizes list them as unsupported.
+        // Logical sectors give the bootloader exactly that, so on a device
+        // whose physical pages are *not* already the logical sector size, the
+        // restriction no longer applies.  Devices whose pages natively match
+        // keep their exclusions: theirs have some other cause (K64fBig's
+        // single slot-sized sector, Nrf52840UnequalSlots' slot sizes).
+        let logical = c::logical_sector_size();
+        let scratch = Caps::SwapUsingScratch.present();
+        let logical_makes_uniform = logical != 0
+            && areadesc.supports_logical_sector_size(logical, scratch)
+            && !areadesc.uses_native_sector_size(logical, scratch);
+
         for cap in unsupported_caps {
-            if cap.present() {
+            if !cap.present() {
+                continue;
+            }
+            let relaxed = logical_makes_uniform
+                && matches!(cap, Caps::SwapUsingMove | Caps::SwapUsingOffset);
+            if !relaxed {
                 return Err(format!("unsupported {:?}", cap));
+            }
+        }
+
+        // Those algorithms spend one logical sector on the trailer and one on
+        // the swap padding, so a slot of two sectors or fewer has no room left
+        // for an image.
+        if logical != 0 && (Caps::SwapUsingMove.present() || Caps::SwapUsingOffset.present()) {
+            let slot = if Caps::SwapUsingOffset.present() {
+                FlashId::Image1
+            } else {
+                FlashId::Image0
+            };
+            if areadesc.find(slot).map(|(_, len, _)| len).unwrap_or(0) <= 2 * logical {
+                return Err("slot too small for logical-sector swap padding and trailer"
+                           .to_string());
             }
         }
 
@@ -209,7 +242,9 @@ impl ImagesBuilder {
     /// Every logical sector boundary must fall on a reported erase page
     /// boundary; the answer is derived from the area description rather than
     /// a list of device names, so it stays correct as devices are added.
-    /// Always true when logical sectors are disabled.
+    /// The scratch area only counts when the build actually uses it, matching
+    /// what `boot_read_sectors()` verifies.  Always true when logical sectors
+    /// are disabled.
     pub fn device_supports_logical_sectors(device: DeviceName, align: usize,
                                            erased_val: u8) -> bool {
         let size = c::logical_sector_size();
@@ -217,7 +252,7 @@ impl ImagesBuilder {
             return true;
         }
         let (_, areadesc, _) = Self::make_device(device, align, erased_val);
-        areadesc.supports_logical_sector_size(size)
+        areadesc.supports_logical_sector_size(size, Caps::SwapUsingScratch.present())
     }
 
     fn device_usable(dev: DeviceName, align: usize, erased_val: u8) -> Result<(), String> {
@@ -248,8 +283,8 @@ impl ImagesBuilder {
         }
     }
 
-    /// Iterate the devices excluded from `each_device` by the
-    /// `logical-sectors-4k` feature.  These layouts must be *rejected* by
+    /// Iterate the devices excluded from `each_device` by the configured
+    /// logical sector size.  These layouts must be *rejected* by
     /// the bootloader's logical sector verification, which the negative
     /// tests exercise.  Devices unbuildable for other reasons (e.g. an
     /// unsupported swap algorithm) are still skipped.

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -590,6 +590,36 @@ impl ImagesBuilder {
                 flash.insert(1, dev1);
                 (flash, Rc::new(areadesc), &[Caps::SwapUsingMove, Caps::SwapUsingOffset])
             }
+            DeviceName::Stm32f769 => {
+                // Faithful 2 MiB STM32F769 in dual-bank mode.  The erase pages
+                // within a slot vary in size (16K, 64K, 128K), which the swap
+                // algorithms that assume uniform sectors cannot handle; a 128K
+                // logical sector tiles the layout exactly and makes them work.
+                let dev = SimFlash::new(vec![
+                                        // Bank 1: 0x000000..0x100000
+                                        16 * 1024, 16 * 1024, 16 * 1024, 16 * 1024, 64 * 1024,
+                                        128 * 1024, 128 * 1024, 128 * 1024, 128 * 1024,
+                                        128 * 1024, 128 * 1024, 128 * 1024,
+                                        // Bank 2: 0x100000..0x200000
+                                        16 * 1024, 16 * 1024, 16 * 1024, 16 * 1024, 64 * 1024,
+                                        128 * 1024, 128 * 1024, 128 * 1024, 128 * 1024,
+                                        128 * 1024, 128 * 1024, 128 * 1024],
+                                        align as usize, erased_val);
+                let dev_id = 0;
+                let mut areadesc = AreaDesc::new();
+                areadesc.add_flash_sectors(dev_id, &dev);
+                // Each slot is 4 logical sectors: 16K*4 + 64K makes the first,
+                // then three 128K pages.  Swap-move and swap-offset need one
+                // sector for the trailer and one for padding, so a slot must
+                // hold more than two.
+                areadesc.add_image(0x000000, 0x080000, FlashId::Image0, dev_id);       // primary,   bank 1
+                areadesc.add_image(0x100000, 0x080000, FlashId::Image1, dev_id);       // secondary, bank 2
+                areadesc.add_image(0x080000, 0x020000, FlashId::ImageScratch, dev_id); // scratch,   bank 1
+
+                let mut flash = SimMultiFlash::new();
+                flash.insert(dev_id, dev);
+                (flash, Rc::new(areadesc), &[Caps::SwapUsingMove, Caps::SwapUsingOffset])
+            }
             DeviceName::K64f => {
                 // NXP style flash.  Small sectors, one small sector for scratch.
                 let dev = SimFlash::new(vec![4096; 128], align as usize, erased_val);

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -205,21 +205,24 @@ impl ImagesBuilder {
     }
 
     /// Whether the sector layout this device reports to the bootloader is
-    /// compatible with the fixed logical sector size selected by the
-    /// `logical-sectors-4k` feature.  Every logical sector boundary must
-    /// fall on a reported erase page boundary, so devices with pages
-    /// larger than 4K (or, like K64fBig, an area description claiming
-    /// slot-sized pages) cannot use 4K logical sectors.
-    pub fn device_supports_logical_sectors(device: DeviceName) -> bool {
-        !matches!(device, DeviceName::Stm32f4
-                  | DeviceName::Stm32f4SpiFlash
-                  | DeviceName::K64fBig
-                  | DeviceName::Nrf52840SpiFlash)
+    /// compatible with the logical sector size the simulator was built with.
+    /// Every logical sector boundary must fall on a reported erase page
+    /// boundary; the answer is derived from the area description rather than
+    /// a list of device names, so it stays correct as devices are added.
+    /// Always true when logical sectors are disabled.
+    pub fn device_supports_logical_sectors(device: DeviceName, align: usize,
+                                           erased_val: u8) -> bool {
+        let size = c::logical_sector_size();
+        if size == 0 {
+            return true;
+        }
+        let (_, areadesc, _) = Self::make_device(device, align, erased_val);
+        areadesc.supports_logical_sector_size(size)
     }
 
-    fn device_usable(dev: DeviceName) -> Result<(), String> {
-        if cfg!(feature = "logical-sectors-4k") {
-            if !Self::device_supports_logical_sectors(dev) {
+    fn device_usable(dev: DeviceName, align: usize, erased_val: u8) -> Result<(), String> {
+        if c::logical_sector_size() != 0 {
+            if !Self::device_supports_logical_sectors(dev, align, erased_val) {
                 return Err("sector layout incompatible with logical sectors".to_string());
             }
         } else if matches!(dev, DeviceName::SmallPages) {
@@ -235,7 +238,8 @@ impl ImagesBuilder {
         for &dev in ALL_DEVICES {
             for &align in test_alignments() {
                 for &erased_val in &[0, 0xff] {
-                    match Self::device_usable(dev).and_then(|()| Self::new(dev, align, erased_val)) {
+                    match Self::device_usable(dev, align, erased_val)
+                            .and_then(|()| Self::new(dev, align, erased_val)) {
                         Ok(run) => f(run),
                         Err(msg) => warn!("Skipping {}: {}", dev, msg),
                     }
@@ -253,11 +257,11 @@ impl ImagesBuilder {
         where F: Fn(Self)
     {
         for &dev in ALL_DEVICES {
-            if Self::device_supports_logical_sectors(dev) {
-                continue;
-            }
             for &align in test_alignments() {
                 for &erased_val in &[0, 0xff] {
+                    if Self::device_supports_logical_sectors(dev, align, erased_val) {
+                        continue;
+                    }
                     match Self::new(dev, align, erased_val) {
                         Ok(run) => f(run),
                         Err(msg) => warn!("Skipping {}: {}", dev, msg),
@@ -1984,14 +1988,12 @@ enum ImageSize {
 
 /// The sector size the bootloader operates on for `dev`: the logical
 /// sector size when the simulator is built with logical sectors, the
-/// device's physical sector size otherwise.  The size here must match
-/// the MCUBOOT_LOGICAL_SECTOR_SIZE value set by mcuboot-sys/build.rs.
-/// The physical case assumes uniform sectors, as does every caller.
+/// device's physical sector size otherwise.  The physical case assumes
+/// uniform sectors, as does every caller.
 fn boot_sector_size(dev: &dyn Flash) -> usize {
-    if cfg!(feature = "logical-sectors-4k") {
-        4096
-    } else {
-        dev.sector_iter().next().unwrap().size
+    match c::logical_sector_size() {
+        0 => dev.sector_iter().next().unwrap().size,
+        size => size,
     }
 }
 
@@ -2015,12 +2017,10 @@ fn estimate_swap_scratch_trailer_size(dev: &dyn Flash, areadesc: &AreaDesc, slot
 
     // Sector sizes as seen by the bootloader: uniform logical sectors
     // when they are enabled, the physical layout otherwise.
-    let slot_sectors: Vec<usize> = if cfg!(feature = "logical-sectors-4k") {
-        let sector_sz = boot_sector_size(dev);
-        vec![sector_sz; slot.len / sector_sz]
-    } else {
-        areadesc.get_area_sectors(flash_id).unwrap()
-            .iter().map(|sector| sector.size as usize).collect()
+    let slot_sectors: Vec<usize> = match c::logical_sector_size() {
+        0 => areadesc.get_area_sectors(flash_id).unwrap()
+                 .iter().map(|sector| sector.size as usize).collect(),
+        size => vec![size; slot.len / size],
     };
 
     for &sector_sz in slot_sectors.iter().rev() {

--- a/sim/src/image.rs
+++ b/sim/src/image.rs
@@ -204,10 +204,53 @@ impl ImagesBuilder {
         })
     }
 
+    /// Whether the sector layout this device reports to the bootloader is
+    /// compatible with the fixed logical sector size selected by the
+    /// `logical-sectors-4k` feature.  Every logical sector boundary must
+    /// fall on a reported erase page boundary, so devices with pages
+    /// larger than 4K (or, like K64fBig, an area description claiming
+    /// slot-sized pages) cannot use 4K logical sectors.
+    pub fn device_supports_logical_sectors(device: DeviceName) -> bool {
+        !matches!(device, DeviceName::Stm32f4
+                  | DeviceName::Stm32f4SpiFlash
+                  | DeviceName::K64fBig
+                  | DeviceName::Nrf52840SpiFlash)
+    }
+
+    fn device_usable(dev: DeviceName) -> Result<(), String> {
+        if cfg!(feature = "logical-sectors-4k") && !Self::device_supports_logical_sectors(dev) {
+            return Err("sector layout incompatible with logical sectors".to_string());
+        }
+        Ok(())
+    }
+
     pub fn each_device<F>(f: F)
         where F: Fn(Self)
     {
         for &dev in ALL_DEVICES {
+            for &align in test_alignments() {
+                for &erased_val in &[0, 0xff] {
+                    match Self::device_usable(dev).and_then(|()| Self::new(dev, align, erased_val)) {
+                        Ok(run) => f(run),
+                        Err(msg) => warn!("Skipping {}: {}", dev, msg),
+                    }
+                }
+            }
+        }
+    }
+
+    /// Iterate the devices excluded from `each_device` by the
+    /// `logical-sectors-4k` feature.  These layouts must be *rejected* by
+    /// the bootloader's logical sector verification, which the negative
+    /// tests exercise.  Devices unbuildable for other reasons (e.g. an
+    /// unsupported swap algorithm) are still skipped.
+    pub fn each_logical_sector_incompatible_device<F>(f: F)
+        where F: Fn(Self)
+    {
+        for &dev in ALL_DEVICES {
+            if Self::device_supports_logical_sectors(dev) {
+                continue;
+            }
             for &align in test_alignments() {
                 for &erased_val in &[0, 0xff] {
                     match Self::new(dev, align, erased_val) {
@@ -1013,6 +1056,55 @@ impl Images {
 
         if fails > 0 {
             error!("Expected an upgrade failure and primary slot left untouched");
+        }
+
+        fails > 0
+    }
+
+    /// Boot with an upgrade staged on a device whose reported sector
+    /// layout is incompatible with the configured logical sector size.
+    /// The bootloader's logical sector verification must refuse to touch
+    /// the flash: the boot fails outright (the primary slot's layout
+    /// cannot be trusted), and both slots keep their original contents.
+    pub fn run_incompatible_logical_sectors(&self) -> bool {
+        if !Caps::modifies_flash() {
+            // direct-xip and ram-load don't use sector layouts at all.
+            return false;
+        }
+
+        let mut flash = self.flash.clone();
+        let mut fails = 0;
+
+        info!("Try upgrade with an incompatible logical sector layout");
+
+        self.mark_upgrades(&mut flash, 1);
+
+        // Snapshot every flash device after staging the upgrade; the
+        // rejected boot must leave all of it byte-identical, trailers
+        // included.
+        let snapshot: Vec<(u8, Vec<u8>)> = flash.iter().map(|(&dev_id, dev)| {
+            let mut data = vec![0u8; dev.device_size()];
+            dev.read(0, &mut data).unwrap();
+            (dev_id, data)
+        }).collect();
+
+        if c::boot_go(&mut flash, &self.areadesc, None, None, false).success() {
+            warn!("Boot unexpectedly succeeded with an incompatible layout");
+            fails += 1;
+        }
+
+        for (dev_id, before) in &snapshot {
+            let dev = flash.get(dev_id).unwrap();
+            let mut after = vec![0u8; dev.device_size()];
+            dev.read(0, &mut after).unwrap();
+            if before != &after {
+                warn!("Flash device {} was modified by the rejected boot", dev_id);
+                fails += 1;
+            }
+        }
+
+        if fails > 0 {
+            error!("Expected a rejected boot with the flash untouched");
         }
 
         fails > 0

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -63,13 +63,14 @@ struct Args {
 
 #[derive(Copy, Clone, Debug, Deserialize)]
 pub enum DeviceName {
-    Stm32f4, Stm32f4SpiFlash, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash,
+    Stm32f4, Stm32f4SpiFlash, Stm32f769, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash,
     Nrf52840UnequalSlots, Nrf52840UnequalSlotsLargerSlot1,PSOCEdgeE8x, SmallPages,
 }
 
 pub static ALL_DEVICES: &[DeviceName] = &[
     DeviceName::Stm32f4,
     DeviceName::Stm32f4SpiFlash,
+    DeviceName::Stm32f769,
     DeviceName::K64f,
     DeviceName::K64fBig,
     DeviceName::K64fMulti,
@@ -86,6 +87,7 @@ impl fmt::Display for DeviceName {
         let name = match *self {
             DeviceName::Stm32f4 => "stm32f4",
             DeviceName::Stm32f4SpiFlash => "stm32f4SpiFlash",
+            DeviceName::Stm32f769 => "stm32f769",
             DeviceName::K64f => "k64f",
             DeviceName::K64fBig => "k64fbig",
             DeviceName::K64fMulti => "k64fmulti",

--- a/sim/src/lib.rs
+++ b/sim/src/lib.rs
@@ -64,7 +64,7 @@ struct Args {
 #[derive(Copy, Clone, Debug, Deserialize)]
 pub enum DeviceName {
     Stm32f4, Stm32f4SpiFlash, K64f, K64fBig, K64fMulti, Nrf52840, Nrf52840SpiFlash,
-    Nrf52840UnequalSlots, Nrf52840UnequalSlotsLargerSlot1,PSOCEdgeE8x,
+    Nrf52840UnequalSlots, Nrf52840UnequalSlotsLargerSlot1,PSOCEdgeE8x, SmallPages,
 }
 
 pub static ALL_DEVICES: &[DeviceName] = &[
@@ -78,6 +78,7 @@ pub static ALL_DEVICES: &[DeviceName] = &[
     DeviceName::Nrf52840UnequalSlots,
     DeviceName::Nrf52840UnequalSlotsLargerSlot1,
     DeviceName::PSOCEdgeE8x,
+    DeviceName::SmallPages,
 ];
 
 impl fmt::Display for DeviceName {
@@ -93,6 +94,7 @@ impl fmt::Display for DeviceName {
             DeviceName::Nrf52840UnequalSlots => "Nrf52840UnequalSlots",
             DeviceName::Nrf52840UnequalSlotsLargerSlot1 => "Nrf52840UnequalSlotsLargerSlot1",
             DeviceName::PSOCEdgeE8x => "PSOCEdgeE8x",
+            DeviceName::SmallPages => "smallpages",
         };
         f.write_str(name)
     }

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -92,7 +92,7 @@ sim_test!(hw_prot_failed_security_cnt_check, make_image_with_security_counter(So
 // fails and the staged, otherwise-valid upgrade is left unapplied.
 // This is the only coverage MCUBOOT_VERIFY_LOGICAL_SECTORS gets, since
 // on compatible devices it succeeds silently.
-#[cfg(feature = "logical-sectors-4k")]
+#[cfg(feature = "logical-sectors")]
 #[test]
 fn logical_sectors_reject_incompatible_devices() {
     testlog::setup();

--- a/sim/tests/core.rs
+++ b/sim/tests/core.rs
@@ -86,6 +86,23 @@ sim_test!(ram_load_corrupt_higher_version_image, make_no_upgrade_image(&NO_DEPS,
 sim_test!(hw_prot_missing_security_cnt, make_image_with_security_counter(None), run_hw_rollback_prot());
 sim_test!(hw_prot_failed_security_cnt_check, make_image_with_security_counter(Some(0)), run_hw_rollback_prot());
 
+// Devices whose erase pages don't line up with the configured logical
+// sector size are excluded from `each_device`, and instead must be
+// rejected by the bootloader's logical sector verification: the boot
+// fails and the staged, otherwise-valid upgrade is left unapplied.
+// This is the only coverage MCUBOOT_VERIFY_LOGICAL_SECTORS gets, since
+// on compatible devices it succeeds silently.
+#[cfg(feature = "logical-sectors-4k")]
+#[test]
+fn logical_sectors_reject_incompatible_devices() {
+    testlog::setup();
+    ImagesBuilder::each_logical_sector_incompatible_device(|r| {
+        let image = r.make_no_upgrade_image(&NO_DEPS, ImageManipulation::None);
+        dump_image(&image, "logical_sectors_reject_incompatible_devices");
+        assert!(!image.run_incompatible_logical_sectors());
+    });
+}
+
 #[cfg(feature = "sig-ed25519")]
 mod multi_key {
     //! Multi-signing-key matrix.


### PR DESCRIPTION
This builds on mcu-tools#2786 to make the logical sector support actually testable in the simulator, and fixes two bugs in the logical sector code that the new tests uncovered.

## Why

The `sim: Test logical sectors` commit adds the feature plumbing, but as it stands the testing is vacuous:

- Nothing in CI builds with `logical-sectors-4k`, so the logical sector code paths are never compiled there.
- Most sim devices already have 4K pages, so logical and physical layouts are indistinguishable and nothing detects whether logical sectors are actually in effect.
- Devices where 4K logical sectors are genuinely invalid (stm32f4 with 16K-128K pages) still pass, because swap-scratch happens to issue slot-sized erases that land on physical page boundaries.
- `MCUBOOT_VERIFY_LOGICAL_SECTORS`, the option meant to catch such misconfigurations, is never built anywhere.

## What this adds

- The sim now builds with `MCUBOOT_VERIFY_LOGICAL_SECTORS` when `logical-sectors-4k` is enabled. Devices whose layout is incompatible with 4K logical sectors are excluded from the normal device iteration and instead covered by a new negative test: a staged, otherwise-valid upgrade must be rejected with both slots left untouched.
- A new `SmallPages` device (512 byte pages, 256 pages per slot, which exceeds `BOOT_MAX_IMG_SECTORS`) that can only boot when logical sectors group pages into larger units. This is the configuration the feature exists for, and it fails if the logical sector define is ever silently dropped.
- A CI matrix row running the suite with logical sectors under swap-scratch, swap-move, swap-offset, overwrite-only, and with ECDSA signing.

## Bugs found and fixed

1. `boot_read_sectors()` ran the logical sector verification but returned 0 unconditionally, so failures were logged and ignored. The fix also reports failures as `BOOT_EFLASH` rather than `BOOT_EFLASH_SEC`: a mismatched logical sector size means no slot may be erased, while `BOOT_EFLASH_SEC` would let the loader re-derive a swap decision from the trailers and start an upgrade on the mismatched layout.
2. The scramble helpers located erase boundaries using physical pages, while the swap algorithms treat logical sectors as erase units. On a device with pages smaller than the logical sector, the trailer scramble erased only the last page, and the swap then wrote the rest of that logical sector without erasing it — corrupting data. The swap-offset secondary header offset had the same physical-vs-logical confusion.

An informational note, not fixed here: in `boot_verify_logical_sectors()`, the `flash_area_get_sector()` error path does `continue` without advancing `sect_off`/`total_scanned`, so if that error ever fired the loop would not terminate. It appears unreachable in practice since offsets stay within the slot.

## Testing

All combinations pass the full suite, including the interrupted-swap permutation tests, with no regression in the no-feature baseline:

| Features | Result |
|---|---|
| `logical-sectors-4k` | 26 passed |
| `logical-sectors-4k swap-move` | 26 passed |
| `logical-sectors-4k swap-offset` | 26 passed |
| `logical-sectors-4k overwrite-only` | 26 passed |
| `sig-ecdsa logical-sectors-4k` | 26 passed |
| baseline, no features | 25 passed |
